### PR TITLE
additional logging for frame tracking, increased max simulated frames per loop

### DIFF
--- a/izzet/client/client.go
+++ b/izzet/client/client.go
@@ -174,6 +174,7 @@ func (g *Client) Start() {
 			accumulator -= float64(settings.MSPerCommandFrame)
 			currentLoopCommandFrames++
 			if currentLoopCommandFrames > settings.MaxCommandFramesPerLoop {
+				g.Logger().Info("ran into max command frames per loop")
 				accumulator = 0
 			}
 

--- a/izzet/client/client.go
+++ b/izzet/client/client.go
@@ -152,7 +152,8 @@ func (g *Client) Start() {
 		accumulator += delta
 		renderAccumulator += delta
 
-		currentLoopCommandFrames := 0
+		numSimulatedFrames := 0
+		startFrame := g.CommandFrame()
 		for accumulator >= float64(settings.MSPerCommandFrame) {
 			g.platform.NewFrame()
 			inputCollector := input.NewInputCollector()
@@ -172,12 +173,15 @@ func (g *Client) Start() {
 			commandFrameCountBeforeRender += 1
 
 			accumulator -= float64(settings.MSPerCommandFrame)
-			currentLoopCommandFrames++
-			if currentLoopCommandFrames > settings.MaxCommandFramesPerLoop {
-				g.Logger().Info("ran into max command frames per loop")
+			numSimulatedFrames++
+			if numSimulatedFrames >= settings.MaxCommandFramesPerLoop {
+				g.Logger().Info("ran into max command frames per loop", "max", settings.MaxCommandFramesPerLoop)
 				accumulator = 0
 			}
+		}
 
+		if numSimulatedFrames > 1 {
+			g.Logger().Info(fmt.Sprintf("simulated %d frames this loop", numSimulatedFrames), "start frame", startFrame)
 		}
 
 		if g.RuntimeConfig().LockRenderingToCommandFrameRate {

--- a/izzet/server/inputbuffer/inputbuffer.go
+++ b/izzet/server/inputbuffer/inputbuffer.go
@@ -19,10 +19,10 @@ type InputBuffer struct {
 }
 
 type PlayerBuffer struct {
-	count             int
-	inputs            []BufferedInput
-	cursor            int
-	lastPulledInputCF int
+	count  int
+	inputs []BufferedInput
+	cursor int
+	// lastPulledInputCF int
 }
 
 type App interface {
@@ -45,11 +45,11 @@ func (b *InputBuffer) DeregisterPlayer(playerID int) {
 func (b *InputBuffer) PushInput(localCommandFrame int, playerID int, frameInput input.Input, stale bool) {
 	buffer := b.playerBuffers[playerID]
 
-	b.app.Logger().Info("push input", "cf", localCommandFrame, "gcf", b.app.CommandFrame(), "stale", stale)
-	if buffer.count > 0 && buffer.inputs[(buffer.count-1)%maxBufferedInput].LocalCommandFrame >= localCommandFrame {
-		b.app.Logger().Info("drop late input", "cf", localCommandFrame, "gcf", b.app.CommandFrame())
-		return
-	}
+	// b.app.Logger().Info("push input", "cf", localCommandFrame, "gcf", b.app.CommandFrame(), "stale", stale)
+	// if buffer.count > 0 && buffer.inputs[(buffer.count-1)%maxBufferedInput].LocalCommandFrame >= localCommandFrame {
+	// 	b.app.Logger().Info("drop late input", "cf", localCommandFrame, "gcf", b.app.CommandFrame())
+	// 	return
+	// }
 
 	buffer.inputs[buffer.count%maxBufferedInput] = BufferedInput{LocalCommandFrame: localCommandFrame, Input: frameInput}
 	buffer.count++
@@ -65,21 +65,21 @@ func (b *InputBuffer) PullInput(playerID int, globalCommandFrame int) BufferedIn
 		return BufferedInput{}
 	}
 
-	stale := false
+	// stale := false
 	if buffer.cursor >= buffer.count && buffer.count != 0 {
-		// buffer.cursor = buffer.count - 1
-		prevInput := buffer.inputs[(buffer.cursor-1)%maxBufferedInput]
-		b.PushInput(prevInput.LocalCommandFrame+1, playerID, prevInput.Input, true)
-		stale = true
+		buffer.cursor = buffer.count - 1
+		// prevInput := buffer.inputs[(buffer.cursor-1)%maxBufferedInput]
+		// b.PushInput(prevInput.LocalCommandFrame+1, playerID, prevInput.Input, true)
+		// stale = true
 	}
 
 	bufferedInput := buffer.inputs[buffer.cursor%maxBufferedInput]
 	buffer.cursor++
 
-	if stale {
-		b.app.Logger().Info("read stale output", "cf", bufferedInput.LocalCommandFrame, "gcf", globalCommandFrame)
-	}
+	// if stale {
+	// 	b.app.Logger().Info("read stale output", "cf", bufferedInput.LocalCommandFrame, "gcf", globalCommandFrame)
+	// }
 
-	buffer.lastPulledInputCF = bufferedInput.LocalCommandFrame
+	// buffer.lastPulledInputCF = bufferedInput.LocalCommandFrame
 	return bufferedInput
 }

--- a/izzet/server/inputbuffer/inputbuffer.go
+++ b/izzet/server/inputbuffer/inputbuffer.go
@@ -42,14 +42,10 @@ func (b *InputBuffer) DeregisterPlayer(playerID int) {
 	delete(b.playerBuffers, playerID)
 }
 
-func (b *InputBuffer) PushInput(localCommandFrame int, playerID int, frameInput input.Input, stale bool) {
+func (b *InputBuffer) PushInput(localCommandFrame int, playerID int, frameInput input.Input) {
 	buffer := b.playerBuffers[playerID]
 
-	// b.app.Logger().Info("push input", "cf", localCommandFrame, "gcf", b.app.CommandFrame(), "stale", stale)
-	// if buffer.count > 0 && buffer.inputs[(buffer.count-1)%maxBufferedInput].LocalCommandFrame >= localCommandFrame {
-	// 	b.app.Logger().Info("drop late input", "cf", localCommandFrame, "gcf", b.app.CommandFrame())
-	// 	return
-	// }
+	b.app.Logger().Info("push input", "cf", localCommandFrame, "gcf", b.app.CommandFrame(), "stale")
 
 	buffer.inputs[buffer.count%maxBufferedInput] = BufferedInput{LocalCommandFrame: localCommandFrame, Input: frameInput}
 	buffer.count++
@@ -65,21 +61,17 @@ func (b *InputBuffer) PullInput(playerID int, globalCommandFrame int) BufferedIn
 		return BufferedInput{}
 	}
 
-	// stale := false
+	stale := false
 	if buffer.cursor >= buffer.count && buffer.count != 0 {
 		buffer.cursor = buffer.count - 1
-		// prevInput := buffer.inputs[(buffer.cursor-1)%maxBufferedInput]
-		// b.PushInput(prevInput.LocalCommandFrame+1, playerID, prevInput.Input, true)
-		// stale = true
 	}
 
 	bufferedInput := buffer.inputs[buffer.cursor%maxBufferedInput]
 	buffer.cursor++
 
-	// if stale {
-	// 	b.app.Logger().Info("read stale output", "cf", bufferedInput.LocalCommandFrame, "gcf", globalCommandFrame)
-	// }
+	if stale {
+		b.app.Logger().Info("read stale output", "cf", bufferedInput.LocalCommandFrame, "gcf", globalCommandFrame)
+	}
 
-	// buffer.lastPulledInputCF = bufferedInput.LocalCommandFrame
 	return bufferedInput
 }

--- a/izzet/server/inputbuffer/inputbuffer.go
+++ b/izzet/server/inputbuffer/inputbuffer.go
@@ -1,10 +1,12 @@
 package inputbuffer
 
 import (
+	"log/slog"
+
 	"github.com/kkevinchou/izzet/internal/input"
 )
 
-const maxBufferedInput int = 3
+const maxBufferedInput int = 10
 
 type BufferedInput struct {
 	Input             input.Input
@@ -13,16 +15,23 @@ type BufferedInput struct {
 
 type InputBuffer struct {
 	playerBuffers map[int]*PlayerBuffer
+	app           App
 }
 
 type PlayerBuffer struct {
-	count  int
-	inputs []BufferedInput
-	cursor int
+	count             int
+	inputs            []BufferedInput
+	cursor            int
+	lastPulledInputCF int
 }
 
-func New() *InputBuffer {
-	return &InputBuffer{playerBuffers: map[int]*PlayerBuffer{}}
+type App interface {
+	Logger() *slog.Logger
+	CommandFrame() int
+}
+
+func New(app App) *InputBuffer {
+	return &InputBuffer{playerBuffers: map[int]*PlayerBuffer{}, app: app}
 }
 
 func (b *InputBuffer) RegisterPlayer(playerID int) {
@@ -33,8 +42,15 @@ func (b *InputBuffer) DeregisterPlayer(playerID int) {
 	delete(b.playerBuffers, playerID)
 }
 
-func (b *InputBuffer) PushInput(localCommandFrame int, playerID int, frameInput input.Input) {
+func (b *InputBuffer) PushInput(localCommandFrame int, playerID int, frameInput input.Input, stale bool) {
 	buffer := b.playerBuffers[playerID]
+
+	b.app.Logger().Info("push input", "cf", localCommandFrame, "gcf", b.app.CommandFrame(), "stale", stale)
+	if buffer.count > 0 && buffer.inputs[(buffer.count-1)%maxBufferedInput].LocalCommandFrame >= localCommandFrame {
+		b.app.Logger().Info("drop late input", "cf", localCommandFrame, "gcf", b.app.CommandFrame())
+		return
+	}
+
 	buffer.inputs[buffer.count%maxBufferedInput] = BufferedInput{LocalCommandFrame: localCommandFrame, Input: frameInput}
 	buffer.count++
 	if buffer.count-buffer.cursor > maxBufferedInput {
@@ -42,18 +58,28 @@ func (b *InputBuffer) PushInput(localCommandFrame int, playerID int, frameInput 
 	}
 }
 
-func (b *InputBuffer) PullInput(playerID int) BufferedInput {
+func (b *InputBuffer) PullInput(playerID int, globalCommandFrame int) BufferedInput {
 	buffer := b.playerBuffers[playerID]
 	if buffer.count == 0 {
 		// fmt.Println("no input found for player", playerID)
 		return BufferedInput{}
 	}
 
+	stale := false
 	if buffer.cursor >= buffer.count && buffer.count != 0 {
-		buffer.cursor = buffer.count - 1
+		// buffer.cursor = buffer.count - 1
+		prevInput := buffer.inputs[(buffer.cursor-1)%maxBufferedInput]
+		b.PushInput(prevInput.LocalCommandFrame+1, playerID, prevInput.Input, true)
+		stale = true
 	}
 
 	bufferedInput := buffer.inputs[buffer.cursor%maxBufferedInput]
 	buffer.cursor++
+
+	if stale {
+		b.app.Logger().Info("read stale output", "cf", bufferedInput.LocalCommandFrame, "gcf", globalCommandFrame)
+	}
+
+	buffer.lastPulledInputCF = bufferedInput.LocalCommandFrame
 	return bufferedInput
 }

--- a/izzet/server/server.go
+++ b/izzet/server/server.go
@@ -70,12 +70,12 @@ func NewWithWorld(world *world.GameWorld, projectName string) *Server {
 	initSeed()
 	g := &Server{
 		players:      map[int]*network.Player{},
-		inputBuffer:  inputbuffer.New(),
 		playerInput:  map[int]input.Input{},
 		eventManager: events.NewEventManager(),
 		projectName:  projectName,
 	}
 
+	g.inputBuffer = inputbuffer.New(g)
 	g.runtimeConfig = runtimeconfig.DefaultRuntimeConfig()
 	g.assetManager = assets.NewAssetManager(false)
 	g.world = world
@@ -136,6 +136,7 @@ func (g *Server) Start(started chan bool, done chan bool) {
 			accumulator -= float64(settings.MSPerCommandFrame)
 			currentLoopCommandFrames++
 			if currentLoopCommandFrames > settings.MaxCommandFramesPerLoop {
+				g.Logger().Info("ran into max command frames per loop")
 				accumulator = 0
 			}
 

--- a/izzet/settings/settings.go
+++ b/izzet/settings/settings.go
@@ -39,7 +39,7 @@ const (
 	MSPerCommandFrame int = 8
 
 	// the maximum number of command frames to execute in a single loop to prevent the spiral of death
-	MaxCommandFramesPerLoop int = 3
+	MaxCommandFramesPerLoop int = 10
 
 	// Animation
 	MaxAnimationJointWeights = 4

--- a/izzet/system/clientsystems/receiver.go
+++ b/izzet/system/clientsystems/receiver.go
@@ -76,20 +76,15 @@ func (s *ReceiverSystem) Update(delta time.Duration, world system.GameWorld) {
 				sb := s.app.StateBuffer()
 				sb.Push(gamestateUpdateMessage, s.app.CommandFrame())
 
-				s.app.Logger().Info("drift", "cf", s.app.CommandFrame(), "server view of cf", gamestateUpdateMessage.LastInputCommandFrame, "delta", gamestateUpdateMessage.LastInputCommandFrame-s.app.CommandFrame())
-
 				// prediction validation
 				cfHistory := s.app.GetCommandFrameHistory()
 				cf, err := cfHistory.GetFrame(gamestateUpdateMessage.LastInputCommandFrame)
 				if err != nil {
-					return
-					// panic(err)
+					panic(err)
 				}
 				state := cf.PostCFState
 				if apputils.Vec3ApproxEqualThreshold(state.Position, serverTransform.Position, 0.001) {
 					mr.Inc("prediction_hit", 1)
-					// if s.app.PredictionDebugLogging() {
-					// 	fmt.Printf("\t - Predictiton Hit [Frame: %d]\n",
 					// 		gamestateUpdateMessage.LastInputCommandFrame,
 					// 	)
 					// }

--- a/izzet/system/clientsystems/receiver.go
+++ b/izzet/system/clientsystems/receiver.go
@@ -76,11 +76,14 @@ func (s *ReceiverSystem) Update(delta time.Duration, world system.GameWorld) {
 				sb := s.app.StateBuffer()
 				sb.Push(gamestateUpdateMessage, s.app.CommandFrame())
 
+				s.app.Logger().Info("drift", "cf", s.app.CommandFrame(), "server view of cf", gamestateUpdateMessage.LastInputCommandFrame, "delta", gamestateUpdateMessage.LastInputCommandFrame-s.app.CommandFrame())
+
 				// prediction validation
 				cfHistory := s.app.GetCommandFrameHistory()
 				cf, err := cfHistory.GetFrame(gamestateUpdateMessage.LastInputCommandFrame)
 				if err != nil {
-					panic(err)
+					return
+					// panic(err)
 				}
 				state := cf.PostCFState
 				if apputils.Vec3ApproxEqualThreshold(state.Position, serverTransform.Position, 0.001) {
@@ -96,6 +99,7 @@ func (s *ReceiverSystem) Update(delta time.Duration, world system.GameWorld) {
 				} else {
 					mr.Inc("prediction_miss", 1)
 					player := s.app.GetPlayerEntity()
+					s.app.Logger().Info("prediction miss", "cf", gamestateUpdateMessage.LastInputCommandFrame)
 
 					// if s.app.PredictionDebugLogging() {
 					// 	fmt.Printf("\t - Predictiton Miss [Frame: %d] [Client: %s] [Server: %s]\n",

--- a/izzet/system/kinematic.go
+++ b/izzet/system/kinematic.go
@@ -28,32 +28,4 @@ func (s *KinematicSystem) Update(delta time.Duration, world GameWorld) {
 	}
 
 	shared.KinematicStep(delta, ents, world, s.app)
-
-	// if s.app.IsClient() && entity != nil {
-	// 	fmt.Println()
-	// }
-
-	// if s.app.IsServer() {
-	// 	player := s.app.GetPlayer(100000)
-	// 	if player != nil {
-	// 		cf = player.LastInputLocalCommandFrame
-	// 	}
-	// }
-
-	// cf := s.app.CommandFrame()
-	// entity := world.GetEntityByID(4586)
-
-	// if entity != nil {
-	// 	logger := s.app.Logger()
-	// 	if s.app.IsClient() {
-	// 		logger.Info("-", "cf", cf, "id", entity.GetID(), "position", apputils.PPrintVec(entity.LocalPosition))
-	// 	} else {
-	// 		player := s.app.GetPlayer(100000)
-	// 		var localCF int
-	// 		if player != nil {
-	// 			localCF = player.LastInputLocalCommandFrame
-	// 		}
-	// 		logger.Info("-", "cf", localCF, "gcf", cf, "id", entity.GetID(), "position", apputils.PPrintVec(entity.LocalPosition))
-	// 	}
-	// }
 }

--- a/izzet/system/kinematic.go
+++ b/izzet/system/kinematic.go
@@ -29,9 +29,6 @@ func (s *KinematicSystem) Update(delta time.Duration, world GameWorld) {
 
 	shared.KinematicStep(delta, ents, world, s.app)
 
-	cf := s.app.CommandFrame()
-	entity := world.GetEntityByID(4586)
-
 	// if s.app.IsClient() && entity != nil {
 	// 	fmt.Println()
 	// }
@@ -43,17 +40,20 @@ func (s *KinematicSystem) Update(delta time.Duration, world GameWorld) {
 	// 	}
 	// }
 
-	if entity != nil {
-		logger := s.app.Logger()
-		if s.app.IsClient() {
-			logger.Info("-", "cf", cf, "id", entity.GetID(), "position", entity.LocalPosition)
-		} else {
-			player := s.app.GetPlayer(100000)
-			var localCF int
-			if player != nil {
-				localCF = player.LastInputLocalCommandFrame
-			}
-			logger.Info("-", "cf", localCF, "gcf", cf, "id", entity.GetID(), "position", entity.LocalPosition)
-		}
-	}
+	// cf := s.app.CommandFrame()
+	// entity := world.GetEntityByID(4586)
+
+	// if entity != nil {
+	// 	logger := s.app.Logger()
+	// 	if s.app.IsClient() {
+	// 		logger.Info("-", "cf", cf, "id", entity.GetID(), "position", apputils.PPrintVec(entity.LocalPosition))
+	// 	} else {
+	// 		player := s.app.GetPlayer(100000)
+	// 		var localCF int
+	// 		if player != nil {
+	// 			localCF = player.LastInputLocalCommandFrame
+	// 		}
+	// 		logger.Info("-", "cf", localCF, "gcf", cf, "id", entity.GetID(), "position", apputils.PPrintVec(entity.LocalPosition))
+	// 	}
+	// }
 }

--- a/izzet/system/serversystems/input.go
+++ b/izzet/system/serversystems/input.go
@@ -21,7 +21,7 @@ func (s *InputSystem) Name() string {
 func (s *InputSystem) Update(delta time.Duration, world system.GameWorld) {
 	inputBuffer := s.app.InputBuffer()
 	for _, player := range s.app.GetPlayers() {
-		bufferedInput := inputBuffer.PullInput(player.ID)
+		bufferedInput := inputBuffer.PullInput(player.ID, s.app.CommandFrame())
 		s.app.SetPlayerInput(player.ID, bufferedInput.Input)
 		player := s.app.GetPlayer(player.ID)
 		player.LastInputLocalCommandFrame = bufferedInput.LocalCommandFrame

--- a/izzet/system/serversystems/receiver.go
+++ b/izzet/system/serversystems/receiver.go
@@ -41,7 +41,7 @@ func (s *ReceiverSystem) Update(delta time.Duration, world system.GameWorld) {
 						fmt.Println(fmt.Errorf("failed to deserialize message %w", err))
 						continue
 					}
-					s.app.InputBuffer().PushInput(message.CommandFrame, player.ID, inputMessage.Input, false)
+					s.app.InputBuffer().PushInput(message.CommandFrame, player.ID, inputMessage.Input)
 				} else if message.MessageType == network.MsgTypePing {
 					pingMessage, err := network.ExtractMessage[network.PingMessage](message)
 					if err != nil {

--- a/izzet/system/serversystems/receiver.go
+++ b/izzet/system/serversystems/receiver.go
@@ -41,7 +41,7 @@ func (s *ReceiverSystem) Update(delta time.Duration, world system.GameWorld) {
 						fmt.Println(fmt.Errorf("failed to deserialize message %w", err))
 						continue
 					}
-					s.app.InputBuffer().PushInput(message.CommandFrame, player.ID, inputMessage.Input)
+					s.app.InputBuffer().PushInput(message.CommandFrame, player.ID, inputMessage.Input, false)
 				} else if message.MessageType == network.MsgTypePing {
 					pingMessage, err := network.ExtractMessage[network.PingMessage](message)
 					if err != nil {

--- a/izzet/system/serversystems/replication.go
+++ b/izzet/system/serversystems/replication.go
@@ -96,6 +96,7 @@ func (s *ReplicationSystem) Update(delta time.Duration, world system.GameWorld) 
 
 	for _, player := range players {
 		gamestateUpdateMessage.LastInputCommandFrame = player.LastInputLocalCommandFrame
+		s.app.Logger().Info("replication", "cf", gamestateUpdateMessage.LastInputCommandFrame, "gcf", s.app.CommandFrame())
 		player.Client.Send(gamestateUpdateMessage, s.app.CommandFrame())
 	}
 }


### PR DESCRIPTION
the lower `MaxCommandFramesPerLoop` was causing the client to drop simulation frames which threw off synchronization with the server. increased the value from `3` -> `10`