### PR TITLE
Gltf optimization

### DIFF
--- a/internal/animation/animationplayer.go
+++ b/internal/animation/animationplayer.go
@@ -14,8 +14,8 @@ type AnimationPlayer struct {
 	animationTransforms map[int]mgl32.Mat4
 	currentAnimation    *modelspec.AnimationSpec
 
-	currentPose     map[int]modelspec.JointTransform
-	blendSourcePose map[int]modelspec.JointTransform
+	currentPose     []modelspec.JointTransform
+	blendSourcePose []modelspec.JointTransform
 	blendDuration   time.Duration
 
 	// these fields are from the loaded animation and should not be modified
@@ -157,20 +157,16 @@ func (player *AnimationPlayer) Length() time.Duration {
 	return player.currentAnimation.Length
 }
 
-func computeJointTransformsHelper(joint *modelspec.JointSpec, parentTransform mgl32.Mat4, poseTransforms map[int]mgl32.Mat4, transforms map[int]mgl32.Mat4) {
-	localTransform := poseTransforms[joint.ID]
+func computeJointTransformsHelper(joint *modelspec.JointSpec, parentTransform mgl32.Mat4, poseTransforms []mgl32.Mat4, transforms map[int]mgl32.Mat4) {
+	// if there is no pose in the animation, just use the local bind transform.
+	// when a pose is present, the keyframe data already includes the local bind transform
+	// using the identity matrix is not correct, we still need the bind transform.
 
-	if _, ok := poseTransforms[joint.ID]; !ok {
-		// if there is no pose in the animation, just use the local bind transform.
-		// when a pose is present, the keyframe data already includes the local bind transform
-
-		// using the identity matrix is not correct, we still need the bind transform.
-		// localTransform = mgl32.Ident4()
-
-		// further down, we multiply by the inverse bind transform which is what allows us
-		// to cancel out the local bind transform and produce the actual output identity matrix
-
-		localTransform = joint.LocalBindTransform
+	// further down, we multiply by the inverse bind transform which is what allows us
+	// to cancel out the local bind transform and produce the actual output identity matrix
+	localTransform := joint.LocalBindTransform
+	if joint.ID >= 0 && joint.ID < len(poseTransforms) {
+		localTransform = poseTransforms[joint.ID]
 	}
 
 	// model-space transform that includes all the parental transforms
@@ -187,7 +183,7 @@ func computeJointTransformsHelper(joint *modelspec.JointSpec, parentTransform mg
 	transforms[joint.ID] = poseTransform.Mul4(joint.InverseBindTransform)
 }
 
-func calculateCurrentAnimationPose(elapsedTime time.Duration, keyFrames []*modelspec.KeyFrame) map[int]modelspec.JointTransform {
+func calculateCurrentAnimationPose(elapsedTime time.Duration, keyFrames []*modelspec.KeyFrame) []modelspec.JointTransform {
 	var startKeyFrame *modelspec.KeyFrame
 	var endKeyFrame *modelspec.KeyFrame
 	var progression float32
@@ -216,8 +212,8 @@ func calculateCurrentAnimationPose(elapsedTime time.Duration, keyFrames []*model
 	return interpolatePoses(startKeyFrame.Pose, endKeyFrame.Pose, progression)
 }
 
-func convertPoseToTransformMatrix(pose map[int]modelspec.JointTransform) map[int]mgl32.Mat4 {
-	transformMatrices := map[int]mgl32.Mat4{}
+func convertPoseToTransformMatrix(pose []modelspec.JointTransform) []mgl32.Mat4 {
+	transformMatrices := make([]mgl32.Mat4, len(pose))
 	for jointID, transform := range pose {
 		translation := transform.Translation
 		rotation := transform.Rotation.Mat4()
@@ -227,7 +223,7 @@ func convertPoseToTransformMatrix(pose map[int]modelspec.JointTransform) map[int
 	return transformMatrices
 }
 
-func interpolatePoses(j1, j2 map[int]modelspec.JointTransform, progression float32) map[int]modelspec.JointTransform {
+func interpolatePoses(j1, j2 []modelspec.JointTransform, progression float32) []modelspec.JointTransform {
 	if progression > 1 {
 		progression = 1
 	}
@@ -236,8 +232,20 @@ func interpolatePoses(j1, j2 map[int]modelspec.JointTransform, progression float
 		progression = 0
 	}
 
-	interpolatedPose := map[int]modelspec.JointTransform{}
-	for jointID := range j1 {
+	if len(j1) == 0 {
+		return clonePose(j2)
+	}
+	if len(j2) == 0 {
+		return clonePose(j1)
+	}
+
+	if len(j1) != len(j2) {
+		panic(fmt.Errorf("joint count from two interpolated poses differ (%d and %d)", len(j1), len(j2)))
+	}
+	jointCount := len(j1)
+
+	interpolatedPose := make([]modelspec.JointTransform, jointCount)
+	for jointID := 0; jointID < jointCount; jointID++ {
 		k1JointTransform := j1[jointID]
 		k2JointTransform := j2[jointID]
 
@@ -256,6 +264,12 @@ func interpolatePoses(j1, j2 map[int]modelspec.JointTransform, progression float
 		}
 	}
 	return interpolatedPose
+}
+
+func clonePose(pose []modelspec.JointTransform) []modelspec.JointTransform {
+	cloned := make([]modelspec.JointTransform, len(pose))
+	copy(cloned, pose)
+	return cloned
 }
 
 func bindPoseHelper(joint *modelspec.JointSpec, transforms map[int]mgl32.Mat4) {

--- a/internal/modelspec/animation.go
+++ b/internal/modelspec/animation.go
@@ -13,10 +13,9 @@ type AnimationSpec struct {
 	Length    time.Duration
 }
 
-// KeyFrame contains a "Pose" which is the mapping from joint index to
-// the transformations that should be applied to the joint for this pose
+// KeyFrame contains a "Pose" indexed by the skin-local joint index.
 type KeyFrame struct {
-	Pose  map[int]JointTransform
+	Pose  []JointTransform
 	Start time.Duration
 }
 

--- a/izzet/assets/loaders/gltf/animation.go
+++ b/izzet/assets/loaders/gltf/animation.go
@@ -1,0 +1,356 @@
+package gltf
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/go-gl/mathgl/mgl32"
+	"github.com/kkevinchou/izzet/internal/modelspec"
+	"github.com/kkevinchou/izzet/internal/utils"
+	"github.com/qmuntal/gltf"
+	"github.com/qmuntal/gltf/modeler"
+)
+
+type jointMeta struct {
+	inverseBindMatrix mgl32.Mat4
+}
+
+type ParsedJoints struct {
+	RootJoint       *modelspec.JointSpec
+	NodeIDToJointID map[int]int
+	JointIDToNodeID map[int]int
+	JointMap        map[int]*modelspec.JointSpec
+}
+
+type preparedAnimationChannel struct {
+	jointID             int
+	path                gltf.TRSProperty
+	timestamps          []float32
+	outputAccessorIndex int
+}
+
+func parseAnimation(ctx *parseContext, document *gltf.Document, animation *gltf.Animation, parsedJoints *ParsedJoints, rootParentTransform mgl32.Mat4) (*modelspec.AnimationSpec, error) {
+	pTranslation, pRotation, pScale := utils.Decompose(rootParentTransform)
+
+	channels, allTimestamps, err := prepareAnimationChannels(ctx, document, animation, parsedJoints)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare animation channels: [%w]", err)
+	}
+
+	jointCount := len(parsedJoints.JointMap)
+	keyFrames := make([]*modelspec.KeyFrame, len(allTimestamps))
+	for i, timestamp := range allTimestamps {
+		pose := make([]modelspec.JointTransform, jointCount)
+		defaultTransform := modelspec.NewDefaultJointTransform()
+		for jointID := range pose {
+			pose[jointID] = defaultTransform
+		}
+		if parsedJoints.RootJoint.ID >= 0 && parsedJoints.RootJoint.ID < len(pose) {
+			// in gltf files, the root joint can be affected by parent nodes that aren't part of the skin.
+			// their transformations still apply, so we bake it into the root joint.
+			pose[parsedJoints.RootJoint.ID] = modelspec.NewJointTransform(pTranslation, pRotation, pScale)
+		}
+
+		// hacky way to keep precision on tiny fractional seconds
+		keyFrames[i] = &modelspec.KeyFrame{
+			Start: time.Duration(timestamp*1000) * time.Millisecond,
+			Pose:  pose,
+		}
+	}
+
+	for _, channel := range channels {
+		timestamps := channel.timestamps
+		if timestamps[0] != allTimestamps[0] {
+			return nil, fmt.Errorf("first timestamp for channel doesn't match first of all collected timestamps")
+		}
+
+		// usage of cursors in the following code is meant to support "optimized" animations
+		// for example, in Blender, if a transform is the same between one frame to the next
+		// it is simply not set. this can be detected when the output count does not match
+		// our collected timestamp count. to handle optimized animations, we simply advance
+		// a cursor that points to the current channel's outputs. if we see a timestamp
+		// that the output cursor is not aware of (since it was optimized away) we copy the
+		// last keyframe's transform
+		outputAccessor := document.Accessors[channel.outputAccessorIndex]
+		if channel.path == gltf.TRSTranslation {
+			if outputAccessor.ComponentType != gltf.ComponentFloat {
+				return nil, fmt.Errorf("unexpected component type %v", outputAccessor.ComponentType)
+			}
+			if outputAccessor.Type != gltf.AccessorVec3 {
+				return nil, fmt.Errorf("unexpected accessor type %v", outputAccessor.Type)
+			}
+			output, err := modeler.ReadAccessor(document, outputAccessor, nil)
+			if err != nil {
+				panic("WHA")
+			}
+			if outputAccessor.Count <= 0 {
+				panic("accessor with 0 count")
+			}
+
+			f32OutputValues := output.([][3]float32)
+
+			localCursor := 0
+			for i, ts := range allTimestamps {
+				if localCursor >= len(timestamps) || timestamps[localCursor] != ts {
+					pose := keyFrames[i].Pose[channel.jointID]
+					pose.Translation = keyFrames[i-1].Pose[channel.jointID].Translation
+					keyFrames[i].Pose[channel.jointID] = pose
+				} else {
+					f32Output := f32OutputValues[localCursor]
+					pose := keyFrames[i].Pose[channel.jointID]
+					pose.Translation = mgl32.Vec3{f32Output[0], f32Output[1], f32Output[2]}
+					keyFrames[i].Pose[channel.jointID] = pose
+					localCursor++
+				}
+			}
+		} else if channel.path == gltf.TRSRotation {
+			if outputAccessor.ComponentType != gltf.ComponentFloat {
+				return nil, fmt.Errorf("unexpected component type %v", outputAccessor.ComponentType)
+			}
+			if outputAccessor.Type != gltf.AccessorVec4 {
+				return nil, fmt.Errorf("unexpected accessor type %v", outputAccessor.Type)
+			}
+			output, err := modeler.ReadAccessor(document, outputAccessor, nil)
+			if err != nil {
+				panic("WHA")
+			}
+			if outputAccessor.Count <= 0 {
+				panic("accessor with 0 count")
+			}
+
+			f32OutputValues := output.([][4]float32)
+
+			localCursor := 0
+			for i, ts := range allTimestamps {
+				if localCursor >= len(timestamps) || timestamps[localCursor] != ts {
+					pose := keyFrames[i].Pose[channel.jointID]
+					pose.Rotation = keyFrames[i-1].Pose[channel.jointID].Rotation
+					keyFrames[i].Pose[channel.jointID] = pose
+				} else {
+					f32Output := f32OutputValues[localCursor]
+					pose := keyFrames[i].Pose[channel.jointID]
+					pose.Rotation = mgl32.Quat{V: mgl32.Vec3{f32Output[0], f32Output[1], f32Output[2]}, W: f32Output[3]}
+					keyFrames[i].Pose[channel.jointID] = pose
+					localCursor++
+				}
+			}
+		} else if channel.path == gltf.TRSScale {
+			if outputAccessor.ComponentType != gltf.ComponentFloat {
+				return nil, fmt.Errorf("unexpected component type %v", outputAccessor.ComponentType)
+			}
+			if outputAccessor.Type != gltf.AccessorVec3 {
+				return nil, fmt.Errorf("unexpected accessor type %v", outputAccessor.Type)
+			}
+			output, err := modeler.ReadAccessor(document, outputAccessor, nil)
+			if err != nil {
+				panic("WHA")
+			}
+			if outputAccessor.Count <= 0 {
+				panic("accessor with 0 count")
+			}
+
+			f32OutputValues := output.([][3]float32)
+
+			localCursor := 0
+			for i, ts := range allTimestamps {
+				// local cursor is ahead, backfill the transform
+				if localCursor >= len(timestamps) || timestamps[localCursor] != ts {
+					pose := keyFrames[i].Pose[channel.jointID]
+					pose.Scale = keyFrames[i-1].Pose[channel.jointID].Scale
+					keyFrames[i].Pose[channel.jointID] = pose
+				} else {
+					f32Output := f32OutputValues[localCursor]
+					pose := keyFrames[i].Pose[channel.jointID]
+					pose.Scale = mgl32.Vec3{f32Output[0], f32Output[1], f32Output[2]}
+					keyFrames[i].Pose[channel.jointID] = pose
+					localCursor++
+				}
+			}
+		}
+	}
+
+	return &modelspec.AnimationSpec{
+		Name:      animation.Name,
+		KeyFrames: keyFrames,
+		Length:    keyFrames[len(keyFrames)-1].Start,
+	}, nil
+}
+
+func parseJoints(document *gltf.Document, skin *gltf.Skin) (*ParsedJoints, error) {
+	jms := map[int]*jointMeta{}
+	jointNodeIDs := uint32SliceToIntSlice(skin.Joints)
+	nodeIDToJointID := map[int]int{}
+	jointIDToNodeID := map[int]int{}
+
+	for jointID, nodeID := range jointNodeIDs {
+		nodeIDToJointID[nodeID] = jointID
+		jointIDToNodeID[jointID] = nodeID
+	}
+
+	for jointID := 0; jointID < len(jointNodeIDs); jointID++ {
+		jms[jointID] = &jointMeta{}
+	}
+
+	acr := document.Accessors[int(*skin.InverseBindMatrices)]
+	if acr.ComponentType != gltf.ComponentFloat {
+		return nil, fmt.Errorf("unexpected component type %v", acr.ComponentType)
+	}
+	if acr.Type != gltf.AccessorMat4 {
+		return nil, fmt.Errorf("unexpected accessor type %v", acr.Type)
+	}
+
+	data, err := modeler.ReadAccessor(document, acr, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	inverseBindMatrices := data.([][4][4]float32)
+	for jointID, _ := range jms {
+		matrix := inverseBindMatrices[jointID]
+		inverseBindMatrix := mgl32.Mat4FromRows(
+			mgl32.Vec4{matrix[0][0], matrix[0][1], matrix[0][2], matrix[0][3]},
+			mgl32.Vec4{matrix[1][0], matrix[1][1], matrix[1][2], matrix[1][3]},
+			mgl32.Vec4{matrix[2][0], matrix[2][1], matrix[2][2], matrix[2][3]},
+			mgl32.Vec4{matrix[3][0], matrix[3][1], matrix[3][2], matrix[3][3]},
+		)
+		jms[jointID].inverseBindMatrix = inverseBindMatrix
+	}
+
+	joints := map[int]*modelspec.JointSpec{}
+	for nodeID, node := range document.Nodes {
+		if _, ok := nodeIDToJointID[nodeID]; !ok {
+			continue
+		}
+
+		jointID := nodeIDToJointID[nodeID]
+
+		translation := node.Translation
+		rotation := node.Rotation
+		scale := node.Scale
+		// from the gltf spec:
+		//
+		// When a node is targeted for animation (referenced by an animation.channel.target),
+		// only TRS properties MAY be present; matrix MUST NOT be present.
+		translationMatrix := mgl32.Translate3D(translation[0], translation[1], translation[2])
+		rotationMatrix := mgl32.Quat{V: mgl32.Vec3{rotation[0], rotation[1], rotation[2]}, W: rotation[3]}.Mat4()
+		scaleMatrix := mgl32.Scale3D(scale[0], scale[1], scale[2])
+
+		joints[jointID] = &modelspec.JointSpec{
+			Name:                 fmt.Sprintf("joint_%s_%d", node.Name, jointID),
+			ID:                   jointID,
+			LocalBindTransform:   translationMatrix.Mul4(rotationMatrix.Mul4(scaleMatrix)),
+			InverseBindTransform: jms[jointID].inverseBindMatrix,
+			FullBindTransform:    jms[jointID].inverseBindMatrix.Inv(),
+		}
+	}
+
+	// set up the joint hierarchy
+	childIDSet := map[int]bool{}
+	for jointID, nodeID := range jointNodeIDs {
+		children := uint32SliceToIntSlice(document.Nodes[nodeID].Children)
+		// there can be children that aren't joints, need to make an explicit check
+		for _, childNodeID := range children {
+			if _, ok := nodeIDToJointID[childNodeID]; !ok {
+				continue
+			}
+			childJointID := nodeIDToJointID[childNodeID]
+			childIDSet[childJointID] = true
+			joints[jointID].Children = append(joints[jointID].Children, joints[childJointID])
+		}
+	}
+
+	root := selectRootJoint(joints, jointNodeIDs, nodeIDToJointID, childIDSet)
+
+	parsedJoints := &ParsedJoints{
+		RootJoint:       root,
+		NodeIDToJointID: nodeIDToJointID,
+		JointIDToNodeID: jointIDToNodeID,
+		JointMap:        joints,
+	}
+	return parsedJoints, nil
+}
+
+func prepareAnimationChannels(ctx *parseContext, document *gltf.Document, animation *gltf.Animation, parsedJoints *ParsedJoints) ([]preparedAnimationChannel, []float32, error) {
+	var preparedChannels []preparedAnimationChannel
+	allTimestamps := map[float32]bool{}
+
+	for _, channel := range animation.Channels {
+		if channel.Target.Node == nil {
+			continue
+		}
+		nodeID := int(*channel.Target.Node)
+		if _, ok := parsedJoints.NodeIDToJointID[nodeID]; !ok {
+			continue
+		}
+
+		jointID := parsedJoints.NodeIDToJointID[nodeID]
+		if channel.Sampler == nil {
+			return nil, nil, fmt.Errorf("animation channel for joint %d has no sampler", jointID)
+		}
+
+		sampler := animation.Samplers[(*channel.Sampler)]
+		if sampler.Interpolation != gltf.InterpolationStep && sampler.Interpolation != gltf.InterpolationLinear {
+			return nil, nil, fmt.Errorf("unsupported interpolation \"%s\" found. only \"%s\" and \"%s\" interpolations are supported",
+				sampler.Interpolation.String(),
+				gltf.InterpolationStep.String(),
+				gltf.InterpolationLinear.String(),
+			)
+		}
+
+		timestamps, err := ctx.readFloatScalarAccessor(document, int(sampler.Input))
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(timestamps) == 0 {
+			return nil, nil, fmt.Errorf("animation channel for joint %d has no timestamps", jointID)
+		}
+
+		for _, timestamp := range timestamps {
+			allTimestamps[timestamp] = true
+		}
+
+		preparedChannels = append(preparedChannels, preparedAnimationChannel{
+			jointID:             jointID,
+			path:                channel.Target.Path,
+			timestamps:          timestamps,
+			outputAccessorIndex: int(sampler.Output),
+		})
+	}
+
+	var timestamps []float32
+	for ts := range allTimestamps {
+		timestamps = append(timestamps, ts)
+	}
+
+	sort.Slice(timestamps, func(i, j int) bool { return timestamps[i] < timestamps[j] })
+	return preparedChannels, timestamps, nil
+}
+
+// a skin requires its joints to share a common parent node known as the root.
+// that root may or may not be a joint (i.e. listed under skin.joints)
+// if skin.skeleton is present, it points to the root node
+//
+// TODO - support multiple skins
+func selectRootJoint(joints map[int]*modelspec.JointSpec, jointNodeIDs []int, nodeIDToJointID map[int]int, childIDSet map[int]bool) *modelspec.JointSpec {
+	for _, nodeID := range jointNodeIDs {
+		jointID := nodeIDToJointID[nodeID]
+		if childIDSet[jointID] {
+			continue
+		}
+
+		joint := joints[jointID]
+		if len(joint.Children) > 0 {
+			return joint
+		}
+	}
+
+	for _, nodeID := range jointNodeIDs {
+		jointID := nodeIDToJointID[nodeID]
+		if !childIDSet[jointID] {
+			return joints[jointID]
+		}
+	}
+
+	return nil
+}

--- a/izzet/assets/loaders/gltf/config.go
+++ b/izzet/assets/loaders/gltf/config.go
@@ -1,0 +1,11 @@
+package gltf
+
+const (
+	TextureCoordStyleOpenGL = 1
+)
+
+type TextureCoordStyle int
+
+type ParseConfig struct {
+	TextureCoordStyle TextureCoordStyle
+}

--- a/izzet/assets/loaders/gltf/context.go
+++ b/izzet/assets/loaders/gltf/context.go
@@ -1,0 +1,45 @@
+package gltf
+
+import (
+	"fmt"
+
+	"github.com/qmuntal/gltf"
+	"github.com/qmuntal/gltf/modeler"
+)
+
+type parseContext struct {
+	floatScalarAccessors map[int][]float32
+}
+
+func newParseContext() *parseContext {
+	return &parseContext{
+		floatScalarAccessors: map[int][]float32{},
+	}
+}
+
+func (ctx *parseContext) readFloatScalarAccessor(document *gltf.Document, accessorIndex int) ([]float32, error) {
+	if values, ok := ctx.floatScalarAccessors[accessorIndex]; ok {
+		return values, nil
+	}
+
+	accessor := document.Accessors[accessorIndex]
+	if accessor.ComponentType != gltf.ComponentFloat {
+		return nil, fmt.Errorf("unexpected component type %v", accessor.ComponentType)
+	}
+	if accessor.Type != gltf.AccessorScalar {
+		return nil, fmt.Errorf("unexpected accessor type %v", accessor.Type)
+	}
+
+	input, err := modeler.ReadAccessor(document, accessor, nil)
+	if err != nil {
+		return nil, fmt.Errorf("read accessor %d: %w", accessorIndex, err)
+	}
+
+	values, ok := input.([]float32)
+	if !ok {
+		return nil, fmt.Errorf("unexpected accessor read type %T", input)
+	}
+
+	ctx.floatScalarAccessors[accessorIndex] = values
+	return values, nil
+}

--- a/izzet/assets/loaders/gltf/gltf.go
+++ b/izzet/assets/loaders/gltf/gltf.go
@@ -37,6 +37,50 @@ type ParseConfig struct {
 	TextureCoordStyle TextureCoordStyle
 }
 
+type parseContext struct {
+	floatScalarAccessors map[int][]float32
+}
+
+type preparedAnimationChannel struct {
+	jointID             int
+	path                gltf.TRSProperty
+	timestamps          []float32
+	outputAccessorIndex int
+}
+
+func newParseContext() *parseContext {
+	return &parseContext{
+		floatScalarAccessors: map[int][]float32{},
+	}
+}
+
+func (ctx *parseContext) readFloatScalarAccessor(document *gltf.Document, accessorIndex int) ([]float32, error) {
+	if values, ok := ctx.floatScalarAccessors[accessorIndex]; ok {
+		return values, nil
+	}
+
+	accessor := document.Accessors[accessorIndex]
+	if accessor.ComponentType != gltf.ComponentFloat {
+		return nil, fmt.Errorf("unexpected component type %v", accessor.ComponentType)
+	}
+	if accessor.Type != gltf.AccessorScalar {
+		return nil, fmt.Errorf("unexpected accessor type %v", accessor.Type)
+	}
+
+	input, err := modeler.ReadAccessor(document, accessor, nil)
+	if err != nil {
+		return nil, fmt.Errorf("read accessor %d: %w", accessorIndex, err)
+	}
+
+	values, ok := input.([]float32)
+	if !ok {
+		return nil, fmt.Errorf("unexpected accessor read type %T", input)
+	}
+
+	ctx.floatScalarAccessors[accessorIndex] = values
+	return values, nil
+}
+
 func GetPeripheralFiles(documentPath string) ([]string, error) {
 	gltfDocument, err := gltf.Open(documentPath)
 	if err != nil {
@@ -75,6 +119,7 @@ func ParseGLTF(name string, documentPath string, config *ParseConfig) (*modelspe
 	if err != nil {
 		return nil, err
 	}
+	ctx := newParseContext()
 
 	document.PeripheralFiles, err = getPeripheralFiles(gltfDocument)
 	if err != nil {
@@ -97,7 +142,7 @@ func ParseGLTF(name string, documentPath string, config *ParseConfig) (*modelspe
 
 		parsedAnimations := map[string]*modelspec.AnimationSpec{}
 		for _, animation := range gltfDocument.Animations {
-			parsedAnimation, err := parseAnimation(gltfDocument, animation, parsedJoints, rootParentTransform)
+			parsedAnimation, err := parseAnimation(ctx, gltfDocument, animation, parsedJoints, rootParentTransform)
 			if err != nil {
 				return nil, err
 			}
@@ -219,122 +264,95 @@ func getNodeTransform(node *gltf.Node) mgl32.Mat4 {
 	return translationMatrix.Mul4(rotationMatrix.Mul4(scaleMatrix))
 }
 
-// preprocessAnimations is a preprocessing method that loops through all animation channels
-// and collects the timestamps associated with them as well as joints that are affected
-// by animations
-func preprocessAnimations(document *gltf.Document, animation *gltf.Animation, parsedJoints *ParsedJoints) ([]float32, []int, error) {
+func prepareAnimationChannels(ctx *parseContext, document *gltf.Document, animation *gltf.Animation, parsedJoints *ParsedJoints) ([]preparedAnimationChannel, []float32, error) {
+	var preparedChannels []preparedAnimationChannel
 	allTimestamps := map[float32]bool{}
-	jointIDs := map[int]bool{}
 
 	for _, channel := range animation.Channels {
+		if channel.Target.Node == nil {
+			continue
+		}
 		nodeID := int(*channel.Target.Node)
 		if _, ok := parsedJoints.NodeIDToJointID[nodeID]; !ok {
 			continue
 		}
 
 		jointID := parsedJoints.NodeIDToJointID[nodeID]
-		jointIDs[jointID] = true
+		if channel.Sampler == nil {
+			return nil, nil, fmt.Errorf("animation channel for joint %d has no sampler", jointID)
+		}
 
 		sampler := animation.Samplers[(*channel.Sampler)]
-		inputAccessorIndex := int(sampler.Input)
-
-		inputAccessor := document.Accessors[inputAccessorIndex]
-		if inputAccessor.ComponentType != gltf.ComponentFloat {
-			return nil, nil, fmt.Errorf("unexpected component type %v", inputAccessor.ComponentType)
-		}
-		if inputAccessor.Type != gltf.AccessorScalar {
-			return nil, nil, fmt.Errorf("unexpected accessor type %v", inputAccessor.Type)
-		}
-
-		input, err := modeler.ReadAccessor(document, inputAccessor, nil)
-		if err != nil {
-			panic("WHA")
-		}
-
-		timestamps := input.([]float32)
-		for _, timestamp := range timestamps {
-			allTimestamps[timestamp] = true
-		}
-	}
-
-	var timestamps []float32
-	for ts, _ := range allTimestamps {
-		timestamps = append(timestamps, ts)
-	}
-
-	var sliceJointIDs []int
-	for jointID := range jointIDs {
-		sliceJointIDs = append(sliceJointIDs, jointID)
-	}
-
-	sort.Slice(timestamps, func(i, j int) bool { return timestamps[i] < timestamps[j] })
-	sort.Ints(sliceJointIDs)
-	return timestamps, sliceJointIDs, nil
-}
-
-func parseAnimation(document *gltf.Document, animation *gltf.Animation, parsedJoints *ParsedJoints, rootParentTransform mgl32.Mat4) (*modelspec.AnimationSpec, error) {
-	keyFrames := map[float32]*modelspec.KeyFrame{}
-
-	pTranslation, pRotation, pScale := utils.Decompose(rootParentTransform)
-
-	allTimestamps, allJointIDs, err := preprocessAnimations(document, animation, parsedJoints)
-	if err != nil {
-		return nil, fmt.Errorf("failed to collect timestamps: [%w]", err)
-	}
-
-	// initialize our initial keyframe datastructure with empty values
-	for _, timestamp := range allTimestamps {
-		// hacky way to keep precision on tiny fractional seconds
-		keyFrames[timestamp] = &modelspec.KeyFrame{
-			Start: time.Duration(timestamp*1000) * time.Millisecond,
-			Pose:  map[int]modelspec.JointTransform{},
-		}
-		for _, jointID := range allJointIDs {
-			keyFrames[timestamp].Pose[jointID] = modelspec.NewDefaultJointTransform()
-			if jointID == parsedJoints.RootJoint.ID {
-				// in gltf files, the root joint can be affected by parent nodes that aren't part of the skin
-				// their transformations still apply, so we bake it into the root joint
-				keyFrames[timestamp].Pose[jointID] = modelspec.NewJointTransform(pTranslation, pRotation, pScale)
-			} else {
-				keyFrames[timestamp].Pose[jointID] = modelspec.NewDefaultJointTransform()
-			}
-		}
-	}
-
-	for _, channel := range animation.Channels {
-		nodeID := int(*channel.Target.Node)
-		if _, ok := parsedJoints.NodeIDToJointID[nodeID]; !ok {
-			continue
-		}
-
-		jointID := parsedJoints.NodeIDToJointID[nodeID]
-		sampler := animation.Samplers[(*channel.Sampler)]
-		inputAccessorIndex := int(sampler.Input)
-		outputAccessorIndex := int(sampler.Output)
 		if sampler.Interpolation != gltf.InterpolationStep && sampler.Interpolation != gltf.InterpolationLinear {
-			return nil, fmt.Errorf("unsupported interpolation \"%s\" found. only \"%s\" and \"%s\" interpolations are supported",
+			return nil, nil, fmt.Errorf("unsupported interpolation \"%s\" found. only \"%s\" and \"%s\" interpolations are supported",
 				sampler.Interpolation.String(),
 				gltf.InterpolationStep.String(),
 				gltf.InterpolationLinear.String(),
 			)
 		}
 
-		inputAccessor := document.Accessors[inputAccessorIndex]
-		if inputAccessor.ComponentType != gltf.ComponentFloat {
-			return nil, fmt.Errorf("unexpected component type %v", inputAccessor.ComponentType)
-		}
-		if inputAccessor.Type != gltf.AccessorScalar {
-			return nil, fmt.Errorf("unexpected accessor type %v", inputAccessor.Type)
-		}
-
-		input, err := modeler.ReadAccessor(document, inputAccessor, nil)
+		timestamps, err := ctx.readFloatScalarAccessor(document, int(sampler.Input))
 		if err != nil {
-			panic("WHA")
+			return nil, nil, err
+		}
+		if len(timestamps) == 0 {
+			return nil, nil, fmt.Errorf("animation channel for joint %d has no timestamps", jointID)
 		}
 
-		timestamps := input.([]float32)
+		for _, timestamp := range timestamps {
+			allTimestamps[timestamp] = true
+		}
+
+		preparedChannels = append(preparedChannels, preparedAnimationChannel{
+			jointID:             jointID,
+			path:                channel.Target.Path,
+			timestamps:          timestamps,
+			outputAccessorIndex: int(sampler.Output),
+		})
+	}
+
+	var timestamps []float32
+	for ts := range allTimestamps {
+		timestamps = append(timestamps, ts)
+	}
+
+	sort.Slice(timestamps, func(i, j int) bool { return timestamps[i] < timestamps[j] })
+	return preparedChannels, timestamps, nil
+}
+
+func parseAnimation(ctx *parseContext, document *gltf.Document, animation *gltf.Animation, parsedJoints *ParsedJoints, rootParentTransform mgl32.Mat4) (*modelspec.AnimationSpec, error) {
+	pTranslation, pRotation, pScale := utils.Decompose(rootParentTransform)
+
+	channels, allTimestamps, err := prepareAnimationChannels(ctx, document, animation, parsedJoints)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare animation channels: [%w]", err)
+	}
+
+	jointCount := len(parsedJoints.JointMap)
+	keyFrames := make([]*modelspec.KeyFrame, len(allTimestamps))
+	for i, timestamp := range allTimestamps {
+		pose := make([]modelspec.JointTransform, jointCount)
+		defaultTransform := modelspec.NewDefaultJointTransform()
+		for jointID := range pose {
+			pose[jointID] = defaultTransform
+		}
+		if parsedJoints.RootJoint.ID >= 0 && parsedJoints.RootJoint.ID < len(pose) {
+			// in gltf files, the root joint can be affected by parent nodes that aren't part of the skin.
+			// their transformations still apply, so we bake it into the root joint.
+			pose[parsedJoints.RootJoint.ID] = modelspec.NewJointTransform(pTranslation, pRotation, pScale)
+		}
+
+		// hacky way to keep precision on tiny fractional seconds
+		keyFrames[i] = &modelspec.KeyFrame{
+			Start: time.Duration(timestamp*1000) * time.Millisecond,
+			Pose:  pose,
+		}
+	}
+
+	for _, channel := range channels {
+		timestamps := channel.timestamps
 		if timestamps[0] != allTimestamps[0] {
-			panic("first timestamp for channel doesn't match first of all collected timestamps")
+			return nil, fmt.Errorf("first timestamp for channel doesn't match first of all collected timestamps")
 		}
 
 		// usage of cursors in the following code is meant to support "optimized" animations
@@ -344,8 +362,8 @@ func parseAnimation(document *gltf.Document, animation *gltf.Animation, parsedJo
 		// a cursor that points to the current channel's outputs. if we see a timestamp
 		// that the output cursor is not aware of (since it was optimized away) we copy the
 		// last keyframe's transform
-		outputAccessor := document.Accessors[outputAccessorIndex]
-		if channel.Target.Path == gltf.TRSTranslation {
+		outputAccessor := document.Accessors[channel.outputAccessorIndex]
+		if channel.path == gltf.TRSTranslation {
 			if outputAccessor.ComponentType != gltf.ComponentFloat {
 				return nil, fmt.Errorf("unexpected component type %v", outputAccessor.ComponentType)
 			}
@@ -364,20 +382,19 @@ func parseAnimation(document *gltf.Document, animation *gltf.Animation, parsedJo
 
 			localCursor := 0
 			for i, ts := range allTimestamps {
-				if timestamps[localCursor] != ts {
-					lastTS := allTimestamps[i-1]
-					pose := keyFrames[ts].Pose[jointID]
-					pose.Translation = keyFrames[lastTS].Pose[jointID].Translation
-					keyFrames[ts].Pose[jointID] = pose
+				if localCursor >= len(timestamps) || timestamps[localCursor] != ts {
+					pose := keyFrames[i].Pose[channel.jointID]
+					pose.Translation = keyFrames[i-1].Pose[channel.jointID].Translation
+					keyFrames[i].Pose[channel.jointID] = pose
 				} else {
 					f32Output := f32OutputValues[localCursor]
-					pose := keyFrames[ts].Pose[jointID]
+					pose := keyFrames[i].Pose[channel.jointID]
 					pose.Translation = mgl32.Vec3{f32Output[0], f32Output[1], f32Output[2]}
-					keyFrames[ts].Pose[jointID] = pose
+					keyFrames[i].Pose[channel.jointID] = pose
 					localCursor++
 				}
 			}
-		} else if channel.Target.Path == gltf.TRSRotation {
+		} else if channel.path == gltf.TRSRotation {
 			if outputAccessor.ComponentType != gltf.ComponentFloat {
 				return nil, fmt.Errorf("unexpected component type %v", outputAccessor.ComponentType)
 			}
@@ -396,20 +413,19 @@ func parseAnimation(document *gltf.Document, animation *gltf.Animation, parsedJo
 
 			localCursor := 0
 			for i, ts := range allTimestamps {
-				if timestamps[localCursor] != ts {
-					lastTS := allTimestamps[i-1]
-					pose := keyFrames[ts].Pose[jointID]
-					pose.Rotation = keyFrames[lastTS].Pose[jointID].Rotation
-					keyFrames[ts].Pose[jointID] = pose
+				if localCursor >= len(timestamps) || timestamps[localCursor] != ts {
+					pose := keyFrames[i].Pose[channel.jointID]
+					pose.Rotation = keyFrames[i-1].Pose[channel.jointID].Rotation
+					keyFrames[i].Pose[channel.jointID] = pose
 				} else {
 					f32Output := f32OutputValues[localCursor]
-					pose := keyFrames[ts].Pose[jointID]
+					pose := keyFrames[i].Pose[channel.jointID]
 					pose.Rotation = mgl32.Quat{V: mgl32.Vec3{f32Output[0], f32Output[1], f32Output[2]}, W: f32Output[3]}
-					keyFrames[ts].Pose[jointID] = pose
+					keyFrames[i].Pose[channel.jointID] = pose
 					localCursor++
 				}
 			}
-		} else if channel.Target.Path == gltf.TRSScale {
+		} else if channel.path == gltf.TRSScale {
 			if outputAccessor.ComponentType != gltf.ComponentFloat {
 				return nil, fmt.Errorf("unexpected component type %v", outputAccessor.ComponentType)
 			}
@@ -429,31 +445,25 @@ func parseAnimation(document *gltf.Document, animation *gltf.Animation, parsedJo
 			localCursor := 0
 			for i, ts := range allTimestamps {
 				// local cursor is ahead, backfill the transform
-				if timestamps[localCursor] != ts {
-					lastTS := allTimestamps[i-1]
-					pose := keyFrames[ts].Pose[jointID]
-					pose.Scale = keyFrames[lastTS].Pose[jointID].Scale
-					keyFrames[ts].Pose[jointID] = pose
+				if localCursor >= len(timestamps) || timestamps[localCursor] != ts {
+					pose := keyFrames[i].Pose[channel.jointID]
+					pose.Scale = keyFrames[i-1].Pose[channel.jointID].Scale
+					keyFrames[i].Pose[channel.jointID] = pose
 				} else {
 					f32Output := f32OutputValues[localCursor]
-					pose := keyFrames[ts].Pose[jointID]
+					pose := keyFrames[i].Pose[channel.jointID]
 					pose.Scale = mgl32.Vec3{f32Output[0], f32Output[1], f32Output[2]}
-					keyFrames[ts].Pose[jointID] = pose
+					keyFrames[i].Pose[channel.jointID] = pose
 					localCursor++
 				}
 			}
 		}
 	}
 
-	var keyFrameSlice []*modelspec.KeyFrame
-	for _, timestamp := range allTimestamps {
-		keyFrameSlice = append(keyFrameSlice, keyFrames[timestamp])
-	}
-
 	return &modelspec.AnimationSpec{
 		Name:      animation.Name,
-		KeyFrames: keyFrameSlice,
-		Length:    keyFrameSlice[len(keyFrameSlice)-1].Start,
+		KeyFrames: keyFrames,
+		Length:    keyFrames[len(keyFrames)-1].Start,
 	}, nil
 }
 

--- a/izzet/assets/loaders/gltf/gltf.go
+++ b/izzet/assets/loaders/gltf/gltf.go
@@ -38,12 +38,16 @@ type ParseConfig struct {
 }
 
 func GetPeripheralFiles(documentPath string) ([]string, error) {
-	var peripheralFiles []string
-
 	gltfDocument, err := gltf.Open(documentPath)
 	if err != nil {
 		return nil, err
 	}
+
+	return getPeripheralFiles(gltfDocument)
+}
+
+func getPeripheralFiles(gltfDocument *gltf.Document) ([]string, error) {
+	var peripheralFiles []string
 
 	// set Peripheral files as they're used and copied over for importing
 	for _, buffer := range gltfDocument.Buffers {
@@ -72,7 +76,7 @@ func ParseGLTF(name string, documentPath string, config *ParseConfig) (*modelspe
 		return nil, err
 	}
 
-	document.PeripheralFiles, err = GetPeripheralFiles(documentPath)
+	document.PeripheralFiles, err = getPeripheralFiles(gltfDocument)
 	if err != nil {
 		return nil, err
 	}

--- a/izzet/assets/loaders/gltf/gltf.go
+++ b/izzet/assets/loaders/gltf/gltf.go
@@ -4,110 +4,14 @@ import (
 	"fmt"
 	"log/slog"
 	"path"
-	"sort"
 	"strings"
-	"time"
 
 	"github.com/go-gl/mathgl/mgl32"
 	"github.com/kkevinchou/izzet/internal/iztlog"
 	"github.com/kkevinchou/izzet/internal/modelspec"
-	"github.com/kkevinchou/izzet/internal/utils"
 	"github.com/qmuntal/gltf"
 	"github.com/qmuntal/gltf/modeler"
 )
-
-type jointMeta struct {
-	inverseBindMatrix mgl32.Mat4
-}
-
-type ParsedJoints struct {
-	RootJoint       *modelspec.JointSpec
-	NodeIDToJointID map[int]int
-	JointIDToNodeID map[int]int
-	JointMap        map[int]*modelspec.JointSpec
-}
-
-type TextureCoordStyle int
-
-const (
-	TextureCoordStyleOpenGL = 1
-)
-
-type ParseConfig struct {
-	TextureCoordStyle TextureCoordStyle
-}
-
-type parseContext struct {
-	floatScalarAccessors map[int][]float32
-}
-
-type preparedAnimationChannel struct {
-	jointID             int
-	path                gltf.TRSProperty
-	timestamps          []float32
-	outputAccessorIndex int
-}
-
-func newParseContext() *parseContext {
-	return &parseContext{
-		floatScalarAccessors: map[int][]float32{},
-	}
-}
-
-func (ctx *parseContext) readFloatScalarAccessor(document *gltf.Document, accessorIndex int) ([]float32, error) {
-	if values, ok := ctx.floatScalarAccessors[accessorIndex]; ok {
-		return values, nil
-	}
-
-	accessor := document.Accessors[accessorIndex]
-	if accessor.ComponentType != gltf.ComponentFloat {
-		return nil, fmt.Errorf("unexpected component type %v", accessor.ComponentType)
-	}
-	if accessor.Type != gltf.AccessorScalar {
-		return nil, fmt.Errorf("unexpected accessor type %v", accessor.Type)
-	}
-
-	input, err := modeler.ReadAccessor(document, accessor, nil)
-	if err != nil {
-		return nil, fmt.Errorf("read accessor %d: %w", accessorIndex, err)
-	}
-
-	values, ok := input.([]float32)
-	if !ok {
-		return nil, fmt.Errorf("unexpected accessor read type %T", input)
-	}
-
-	ctx.floatScalarAccessors[accessorIndex] = values
-	return values, nil
-}
-
-func GetPeripheralFiles(documentPath string) ([]string, error) {
-	gltfDocument, err := gltf.Open(documentPath)
-	if err != nil {
-		return nil, err
-	}
-
-	return getPeripheralFiles(gltfDocument)
-}
-
-func getPeripheralFiles(gltfDocument *gltf.Document) ([]string, error) {
-	var peripheralFiles []string
-
-	// set Peripheral files as they're used and copied over for importing
-	for _, buffer := range gltfDocument.Buffers {
-		if buffer.URI != "" {
-			peripheralFiles = append(peripheralFiles, buffer.URI)
-		}
-	}
-
-	for _, image := range gltfDocument.Images {
-		if image.URI != "" {
-			peripheralFiles = append(peripheralFiles, image.URI)
-		}
-	}
-
-	return peripheralFiles, nil
-}
 
 func ParseGLTF(name string, documentPath string, config *ParseConfig) (*modelspec.Document, error) {
 	logger := iztlog.Logger.With("document path", documentPath)
@@ -202,6 +106,34 @@ func ParseGLTF(name string, documentPath string, config *ParseConfig) (*modelspe
 	return &document, nil
 }
 
+func GetPeripheralFiles(documentPath string) ([]string, error) {
+	gltfDocument, err := gltf.Open(documentPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return getPeripheralFiles(gltfDocument)
+}
+
+func getPeripheralFiles(gltfDocument *gltf.Document) ([]string, error) {
+	var peripheralFiles []string
+
+	// set Peripheral files as they're used and copied over for importing
+	for _, buffer := range gltfDocument.Buffers {
+		if buffer.URI != "" {
+			peripheralFiles = append(peripheralFiles, buffer.URI)
+		}
+	}
+
+	for _, image := range gltfDocument.Images {
+		if image.URI != "" {
+			peripheralFiles = append(peripheralFiles, image.URI)
+		}
+	}
+
+	return peripheralFiles, nil
+}
+
 func parseNode(document *gltf.Document, root uint32) *modelspec.Node {
 	docNode := document.Nodes[int(root)]
 
@@ -262,331 +194,6 @@ func getNodeTransform(node *gltf.Node) mgl32.Mat4 {
 	scaleMatrix := mgl32.Scale3D(scale[0], scale[1], scale[2])
 
 	return translationMatrix.Mul4(rotationMatrix.Mul4(scaleMatrix))
-}
-
-func prepareAnimationChannels(ctx *parseContext, document *gltf.Document, animation *gltf.Animation, parsedJoints *ParsedJoints) ([]preparedAnimationChannel, []float32, error) {
-	var preparedChannels []preparedAnimationChannel
-	allTimestamps := map[float32]bool{}
-
-	for _, channel := range animation.Channels {
-		if channel.Target.Node == nil {
-			continue
-		}
-		nodeID := int(*channel.Target.Node)
-		if _, ok := parsedJoints.NodeIDToJointID[nodeID]; !ok {
-			continue
-		}
-
-		jointID := parsedJoints.NodeIDToJointID[nodeID]
-		if channel.Sampler == nil {
-			return nil, nil, fmt.Errorf("animation channel for joint %d has no sampler", jointID)
-		}
-
-		sampler := animation.Samplers[(*channel.Sampler)]
-		if sampler.Interpolation != gltf.InterpolationStep && sampler.Interpolation != gltf.InterpolationLinear {
-			return nil, nil, fmt.Errorf("unsupported interpolation \"%s\" found. only \"%s\" and \"%s\" interpolations are supported",
-				sampler.Interpolation.String(),
-				gltf.InterpolationStep.String(),
-				gltf.InterpolationLinear.String(),
-			)
-		}
-
-		timestamps, err := ctx.readFloatScalarAccessor(document, int(sampler.Input))
-		if err != nil {
-			return nil, nil, err
-		}
-		if len(timestamps) == 0 {
-			return nil, nil, fmt.Errorf("animation channel for joint %d has no timestamps", jointID)
-		}
-
-		for _, timestamp := range timestamps {
-			allTimestamps[timestamp] = true
-		}
-
-		preparedChannels = append(preparedChannels, preparedAnimationChannel{
-			jointID:             jointID,
-			path:                channel.Target.Path,
-			timestamps:          timestamps,
-			outputAccessorIndex: int(sampler.Output),
-		})
-	}
-
-	var timestamps []float32
-	for ts := range allTimestamps {
-		timestamps = append(timestamps, ts)
-	}
-
-	sort.Slice(timestamps, func(i, j int) bool { return timestamps[i] < timestamps[j] })
-	return preparedChannels, timestamps, nil
-}
-
-func parseAnimation(ctx *parseContext, document *gltf.Document, animation *gltf.Animation, parsedJoints *ParsedJoints, rootParentTransform mgl32.Mat4) (*modelspec.AnimationSpec, error) {
-	pTranslation, pRotation, pScale := utils.Decompose(rootParentTransform)
-
-	channels, allTimestamps, err := prepareAnimationChannels(ctx, document, animation, parsedJoints)
-	if err != nil {
-		return nil, fmt.Errorf("failed to prepare animation channels: [%w]", err)
-	}
-
-	jointCount := len(parsedJoints.JointMap)
-	keyFrames := make([]*modelspec.KeyFrame, len(allTimestamps))
-	for i, timestamp := range allTimestamps {
-		pose := make([]modelspec.JointTransform, jointCount)
-		defaultTransform := modelspec.NewDefaultJointTransform()
-		for jointID := range pose {
-			pose[jointID] = defaultTransform
-		}
-		if parsedJoints.RootJoint.ID >= 0 && parsedJoints.RootJoint.ID < len(pose) {
-			// in gltf files, the root joint can be affected by parent nodes that aren't part of the skin.
-			// their transformations still apply, so we bake it into the root joint.
-			pose[parsedJoints.RootJoint.ID] = modelspec.NewJointTransform(pTranslation, pRotation, pScale)
-		}
-
-		// hacky way to keep precision on tiny fractional seconds
-		keyFrames[i] = &modelspec.KeyFrame{
-			Start: time.Duration(timestamp*1000) * time.Millisecond,
-			Pose:  pose,
-		}
-	}
-
-	for _, channel := range channels {
-		timestamps := channel.timestamps
-		if timestamps[0] != allTimestamps[0] {
-			return nil, fmt.Errorf("first timestamp for channel doesn't match first of all collected timestamps")
-		}
-
-		// usage of cursors in the following code is meant to support "optimized" animations
-		// for example, in Blender, if a transform is the same between one frame to the next
-		// it is simply not set. this can be detected when the output count does not match
-		// our collected timestamp count. to handle optimized animations, we simply advance
-		// a cursor that points to the current channel's outputs. if we see a timestamp
-		// that the output cursor is not aware of (since it was optimized away) we copy the
-		// last keyframe's transform
-		outputAccessor := document.Accessors[channel.outputAccessorIndex]
-		if channel.path == gltf.TRSTranslation {
-			if outputAccessor.ComponentType != gltf.ComponentFloat {
-				return nil, fmt.Errorf("unexpected component type %v", outputAccessor.ComponentType)
-			}
-			if outputAccessor.Type != gltf.AccessorVec3 {
-				return nil, fmt.Errorf("unexpected accessor type %v", outputAccessor.Type)
-			}
-			output, err := modeler.ReadAccessor(document, outputAccessor, nil)
-			if err != nil {
-				panic("WHA")
-			}
-			if outputAccessor.Count <= 0 {
-				panic("accessor with 0 count")
-			}
-
-			f32OutputValues := output.([][3]float32)
-
-			localCursor := 0
-			for i, ts := range allTimestamps {
-				if localCursor >= len(timestamps) || timestamps[localCursor] != ts {
-					pose := keyFrames[i].Pose[channel.jointID]
-					pose.Translation = keyFrames[i-1].Pose[channel.jointID].Translation
-					keyFrames[i].Pose[channel.jointID] = pose
-				} else {
-					f32Output := f32OutputValues[localCursor]
-					pose := keyFrames[i].Pose[channel.jointID]
-					pose.Translation = mgl32.Vec3{f32Output[0], f32Output[1], f32Output[2]}
-					keyFrames[i].Pose[channel.jointID] = pose
-					localCursor++
-				}
-			}
-		} else if channel.path == gltf.TRSRotation {
-			if outputAccessor.ComponentType != gltf.ComponentFloat {
-				return nil, fmt.Errorf("unexpected component type %v", outputAccessor.ComponentType)
-			}
-			if outputAccessor.Type != gltf.AccessorVec4 {
-				return nil, fmt.Errorf("unexpected accessor type %v", outputAccessor.Type)
-			}
-			output, err := modeler.ReadAccessor(document, outputAccessor, nil)
-			if err != nil {
-				panic("WHA")
-			}
-			if outputAccessor.Count <= 0 {
-				panic("accessor with 0 count")
-			}
-
-			f32OutputValues := output.([][4]float32)
-
-			localCursor := 0
-			for i, ts := range allTimestamps {
-				if localCursor >= len(timestamps) || timestamps[localCursor] != ts {
-					pose := keyFrames[i].Pose[channel.jointID]
-					pose.Rotation = keyFrames[i-1].Pose[channel.jointID].Rotation
-					keyFrames[i].Pose[channel.jointID] = pose
-				} else {
-					f32Output := f32OutputValues[localCursor]
-					pose := keyFrames[i].Pose[channel.jointID]
-					pose.Rotation = mgl32.Quat{V: mgl32.Vec3{f32Output[0], f32Output[1], f32Output[2]}, W: f32Output[3]}
-					keyFrames[i].Pose[channel.jointID] = pose
-					localCursor++
-				}
-			}
-		} else if channel.path == gltf.TRSScale {
-			if outputAccessor.ComponentType != gltf.ComponentFloat {
-				return nil, fmt.Errorf("unexpected component type %v", outputAccessor.ComponentType)
-			}
-			if outputAccessor.Type != gltf.AccessorVec3 {
-				return nil, fmt.Errorf("unexpected accessor type %v", outputAccessor.Type)
-			}
-			output, err := modeler.ReadAccessor(document, outputAccessor, nil)
-			if err != nil {
-				panic("WHA")
-			}
-			if outputAccessor.Count <= 0 {
-				panic("accessor with 0 count")
-			}
-
-			f32OutputValues := output.([][3]float32)
-
-			localCursor := 0
-			for i, ts := range allTimestamps {
-				// local cursor is ahead, backfill the transform
-				if localCursor >= len(timestamps) || timestamps[localCursor] != ts {
-					pose := keyFrames[i].Pose[channel.jointID]
-					pose.Scale = keyFrames[i-1].Pose[channel.jointID].Scale
-					keyFrames[i].Pose[channel.jointID] = pose
-				} else {
-					f32Output := f32OutputValues[localCursor]
-					pose := keyFrames[i].Pose[channel.jointID]
-					pose.Scale = mgl32.Vec3{f32Output[0], f32Output[1], f32Output[2]}
-					keyFrames[i].Pose[channel.jointID] = pose
-					localCursor++
-				}
-			}
-		}
-	}
-
-	return &modelspec.AnimationSpec{
-		Name:      animation.Name,
-		KeyFrames: keyFrames,
-		Length:    keyFrames[len(keyFrames)-1].Start,
-	}, nil
-}
-
-func parseJoints(document *gltf.Document, skin *gltf.Skin) (*ParsedJoints, error) {
-	jms := map[int]*jointMeta{}
-	jointNodeIDs := uint32SliceToIntSlice(skin.Joints)
-	nodeIDToJointID := map[int]int{}
-	jointIDToNodeID := map[int]int{}
-
-	for jointID, nodeID := range jointNodeIDs {
-		nodeIDToJointID[nodeID] = jointID
-		jointIDToNodeID[jointID] = nodeID
-	}
-
-	for jointID := 0; jointID < len(jointNodeIDs); jointID++ {
-		jms[jointID] = &jointMeta{}
-	}
-
-	acr := document.Accessors[int(*skin.InverseBindMatrices)]
-	if acr.ComponentType != gltf.ComponentFloat {
-		return nil, fmt.Errorf("unexpected component type %v", acr.ComponentType)
-	}
-	if acr.Type != gltf.AccessorMat4 {
-		return nil, fmt.Errorf("unexpected accessor type %v", acr.Type)
-	}
-
-	data, err := modeler.ReadAccessor(document, acr, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	inverseBindMatrices := data.([][4][4]float32)
-	for jointID, _ := range jms {
-		matrix := inverseBindMatrices[jointID]
-		inverseBindMatrix := mgl32.Mat4FromRows(
-			mgl32.Vec4{matrix[0][0], matrix[0][1], matrix[0][2], matrix[0][3]},
-			mgl32.Vec4{matrix[1][0], matrix[1][1], matrix[1][2], matrix[1][3]},
-			mgl32.Vec4{matrix[2][0], matrix[2][1], matrix[2][2], matrix[2][3]},
-			mgl32.Vec4{matrix[3][0], matrix[3][1], matrix[3][2], matrix[3][3]},
-		)
-		jms[jointID].inverseBindMatrix = inverseBindMatrix
-	}
-
-	joints := map[int]*modelspec.JointSpec{}
-	for nodeID, node := range document.Nodes {
-		if _, ok := nodeIDToJointID[nodeID]; !ok {
-			continue
-		}
-
-		jointID := nodeIDToJointID[nodeID]
-
-		translation := node.Translation
-		rotation := node.Rotation
-		scale := node.Scale
-		// from the gltf spec:
-		//
-		// When a node is targeted for animation (referenced by an animation.channel.target),
-		// only TRS properties MAY be present; matrix MUST NOT be present.
-		translationMatrix := mgl32.Translate3D(translation[0], translation[1], translation[2])
-		rotationMatrix := mgl32.Quat{V: mgl32.Vec3{rotation[0], rotation[1], rotation[2]}, W: rotation[3]}.Mat4()
-		scaleMatrix := mgl32.Scale3D(scale[0], scale[1], scale[2])
-
-		joints[jointID] = &modelspec.JointSpec{
-			Name:                 fmt.Sprintf("joint_%s_%d", node.Name, jointID),
-			ID:                   jointID,
-			LocalBindTransform:   translationMatrix.Mul4(rotationMatrix.Mul4(scaleMatrix)),
-			InverseBindTransform: jms[jointID].inverseBindMatrix,
-			FullBindTransform:    jms[jointID].inverseBindMatrix.Inv(),
-		}
-	}
-
-	// set up the joint hierarchy
-	childIDSet := map[int]bool{}
-	for jointID, nodeID := range jointNodeIDs {
-		children := uint32SliceToIntSlice(document.Nodes[nodeID].Children)
-		// there can be children that aren't joints, need to make an explicit check
-		for _, childNodeID := range children {
-			if _, ok := nodeIDToJointID[childNodeID]; !ok {
-				continue
-			}
-			childJointID := nodeIDToJointID[childNodeID]
-			childIDSet[childJointID] = true
-			joints[jointID].Children = append(joints[jointID].Children, joints[childJointID])
-		}
-	}
-
-	root := selectRootJoint(joints, jointNodeIDs, nodeIDToJointID, childIDSet)
-
-	parsedJoints := &ParsedJoints{
-		RootJoint:       root,
-		NodeIDToJointID: nodeIDToJointID,
-		JointIDToNodeID: jointIDToNodeID,
-		JointMap:        joints,
-	}
-	return parsedJoints, nil
-}
-
-// a skin requires its joints to share a common parent node known as the root.
-// that root may or may not be a joint (i.e. listed under skin.joints)
-// if skin.skeleton is present, it points to the root node
-//
-// TODO - support multiple skins
-func selectRootJoint(joints map[int]*modelspec.JointSpec, jointNodeIDs []int, nodeIDToJointID map[int]int, childIDSet map[int]bool) *modelspec.JointSpec {
-	for _, nodeID := range jointNodeIDs {
-		jointID := nodeIDToJointID[nodeID]
-		if childIDSet[jointID] {
-			continue
-		}
-
-		joint := joints[jointID]
-		if len(joint.Children) > 0 {
-			return joint
-		}
-	}
-
-	for _, nodeID := range jointNodeIDs {
-		jointID := nodeIDToJointID[nodeID]
-		if !childIDSet[jointID] {
-			return joints[jointID]
-		}
-	}
-
-	return nil
 }
 
 // parseMaterialSpecs creates MaterialSpecifications from the gltf materials list
@@ -758,22 +365,6 @@ func loosenUint16Array(uints [][4]uint16) [][]int {
 		for j, uint := range children {
 			result[i][j] = int(uint)
 		}
-	}
-	return result
-}
-
-func loosenFloat32Array2ToVec(floats [][2]float32) []mgl32.Vec2 {
-	var result []mgl32.Vec2
-	for _, props := range floats {
-		result = append(result, mgl32.Vec2(props))
-	}
-	return result
-}
-
-func loosenFloat32Array3ToVec(floats [][3]float32) []mgl32.Vec3 {
-	var result []mgl32.Vec3
-	for _, props := range floats {
-		result = append(result, mgl32.Vec3(props))
 	}
 	return result
 }

--- a/izzet/assets/loaders/gltf/gltf.go
+++ b/izzet/assets/loaders/gltf/gltf.go
@@ -81,19 +81,6 @@ func ParseGLTF(name string, documentPath string, config *ParseConfig) (*modelspe
 		return nil, err
 	}
 
-	// set Peripheral files as they're used and copied over for importing
-	for _, buffer := range gltfDocument.Buffers {
-		if buffer.URI != "" {
-			document.PeripheralFiles = append(document.PeripheralFiles, buffer.URI)
-		}
-	}
-
-	for _, image := range gltfDocument.Images {
-		if image.URI != "" {
-			document.PeripheralFiles = append(document.PeripheralFiles, image.URI)
-		}
-	}
-
 	var parsedJoints *ParsedJoints
 	for _, skin := range gltfDocument.Skins {
 		parsedJoints, err = parseJoints(gltfDocument, skin)

--- a/izzet/assets/loaders/gltf/gltf_test.go
+++ b/izzet/assets/loaders/gltf/gltf_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kkevinchou/izzet/izzet/assets/loaders/gltf"
 )
 
-var testFile string = "../../../../_assets/gltf/velociraptor.gltf"
+var testFile string = "../../../../_assets/gltf/mannequin_m.gltf"
 
 // bug hint: when a joint is defined but has no poses our
 // animation loading code freaks out. i removed the joint animatiosn from the legs

--- a/izzet/assets/loaders/loaders.go
+++ b/izzet/assets/loaders/loaders.go
@@ -6,7 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/kkevinchou/izzet/internal/iztlog"
 	"github.com/kkevinchou/izzet/internal/modelspec"
 	"github.com/kkevinchou/izzet/internal/utils"
 	"github.com/kkevinchou/izzet/izzet/assets/fonts"
@@ -117,7 +119,9 @@ func LoadDocuments(directory string) map[string]*modelspec.Document {
 		}
 
 		if metaData.Extension == ".gltf" {
+			start := time.Now()
 			scene := LoadDocument(metaData.Name, metaData.Path)
+			iztlog.ClientLogger.Info("load document", "name", metaData.Name, "time", time.Since(start).Milliseconds())
 			scenes[metaData.Name] = scene
 		} else {
 			panic(fmt.Sprintf("wtf unexpected extension %s", metaData.Extension))
@@ -125,10 +129,6 @@ func LoadDocuments(directory string) map[string]*modelspec.Document {
 	}
 
 	return scenes
-}
-
-func GetPeripheralFiles(filepath string) ([]string, error) {
-	return gltf.GetPeripheralFiles(filepath)
 }
 
 func LoadDocument(name string, filepath string) *modelspec.Document {

--- a/izzet/client/clientapi.go
+++ b/izzet/client/clientapi.go
@@ -20,7 +20,7 @@ import (
 	"github.com/kkevinchou/izzet/internal/platforms"
 	"github.com/kkevinchou/izzet/internal/utils"
 	"github.com/kkevinchou/izzet/izzet/assets"
-	"github.com/kkevinchou/izzet/izzet/assets/loaders"
+	"github.com/kkevinchou/izzet/izzet/assets/loaders/gltf"
 	"github.com/kkevinchou/izzet/izzet/client/edithistory"
 	"github.com/kkevinchou/izzet/izzet/collisionobserver"
 	"github.com/kkevinchou/izzet/izzet/entity"
@@ -370,7 +370,7 @@ func (g *Client) DeleteDocument(documentAsset assets.DocumentAsset) []int {
 }
 
 func (g *Client) CopyDocumentToProjectFolder(config assets.AssetConfig) assets.AssetConfig {
-	peripheralFiles, err := loaders.GetPeripheralFiles(config.FilePath)
+	peripheralFiles, err := gltf.GetPeripheralFiles(config.FilePath)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- `KeyFrame.Pose` changed from `map[int]JointTransform` to `[]JointTransform`
- `parseAnimation` no longer uses a `map[float32]*KeyFrame` internally. It builds sorted keyframes as a slice and writes by index
- The old code scanned channels twice: once in preprocessAnimations, then again to fill poses. The new prepareAnimationChannels pass collects channel metadata and timestamps once
- Timestamp accessors are cached